### PR TITLE
INFRA-102: findObject method to fail when search results do not fully match the search keys

### DIFF
--- a/app/spec/utils/utils.spec.js
+++ b/app/spec/utils/utils.spec.js
@@ -3,6 +3,8 @@
 describe("Utils", function() {
   const folderInTest = __dirname + "/../../src/utils/";
   const fs = require("fs");
+  const _ = require("lodash");
+
   const utils = require(folderInTest + "utils");
   const model = require(folderInTest + "model");
 
@@ -128,5 +130,72 @@ describe("Utils", function() {
 
     // verif: undefined remains undefined
     expect(obj).toEqual(undefined);
+  });
+
+  it("should find object based on keyMap.", function() {
+    var expectedError1 = new Error(
+      "Illegal state: provided search keys were partially matched on the target objects"
+    );
+    var expectedError2 = new Error(
+      "Illegal state: multiple objects matching the search keys"
+    );
+
+    var objects = [
+      {
+        uuid: "uuid-A",
+        name: "staging-cambodia"
+      },
+      {
+        uuid: "uuid-B",
+        name: "staging-cambodia"
+      },
+      {
+        uuid: "uuid-B",
+        name: "dev-cambodia"
+      },
+      {
+        uuid: "uuid-D",
+        name: "prod-cambodia"
+      }
+    ];
+
+    var keyPairs = {
+      uuid: "uuid-A"
+    };
+    expect(utils.findObject(keyPairs, objects).uuid).toEqual("uuid-A");
+
+    var keyPairs = {
+      uuid: "uuid-D",
+      name: "prod-cambodia"
+    };
+    expect(utils.findObject(keyPairs, objects).uuid).toEqual("uuid-D");
+
+    keyPairs = {
+      uuid: "uuid-B",
+      name: "staging-cambodia"
+    };
+    expect(function() {
+      utils.findObject(keyPairs, objects);
+    }).toThrow(expectedError1);
+
+    keyPairs = {
+      uuid: ""
+    };
+    expect(_.isEmpty(utils.findObject(keyPairs, objects))).toEqual(true);
+
+    var keyPairs = {
+      uuid: "uuid-D",
+      name: "dev-cambodia"
+    };
+    expect(function() {
+      utils.findObject(keyPairs, objects);
+    }).toThrow(expectedError1);
+
+    keyPairs = {
+      name: "staging-cambodia"
+    };
+    expect(function() {
+      utils.findObject(keyPairs, objects);
+    }).toThrow(expectedError2);
   });
 });

--- a/app/spec/utils/utils.spec.js
+++ b/app/spec/utils/utils.spec.js
@@ -134,10 +134,10 @@ describe("Utils", function() {
 
   it("should find object based on keyMap.", function() {
     var expectedError1 = new Error(
-      "Illegal state: provided search keys were partially matched on the target objects"
+      "Illegal state: search keys were only partially matched when searching collection"
     );
     var expectedError2 = new Error(
-      "Illegal state: multiple objects matching the search keys"
+      "Illegal state: search keys were matched multiple times when searching collection"
     );
 
     var objects = [

--- a/app/src/utils/db.js
+++ b/app/src/utils/db.js
@@ -261,10 +261,7 @@ var getAllObjects = function(domainName, dbFilePath) {
  * @return The matched object in the data domain.
  */
 var getObject = function(domainName, dbFilePath, keyPairs) {
-    log.info(
-      "",
-      "Fetching an object in the data domain '" + domainName + "'..."
-    )
+  log.info("", "Fetching an object in the data domain '" + domainName + "'...");
   log.info("", JSON.stringify(keyPairs, null, 2));
 
   var objects = getAllObjects(domainName, dbFilePath);

--- a/app/src/utils/db.js
+++ b/app/src/utils/db.js
@@ -261,13 +261,10 @@ var getAllObjects = function(domainName, dbFilePath) {
  * @return The matched object in the data domain.
  */
 var getObject = function(domainName, dbFilePath, keyPairs) {
-  log.info(
-    "",
     log.info(
       "",
       "Fetching an object in the data domain '" + domainName + "'..."
     )
-  );
   log.info("", JSON.stringify(keyPairs, null, 2));
 
   var objects = getAllObjects(domainName, dbFilePath);

--- a/app/src/utils/utils.js
+++ b/app/src/utils/utils.js
@@ -163,7 +163,6 @@ module.exports = {
    */
   findObject: function(keyPairs, objects) {
     var filteredObjects = _.filter(objects, function(o) {
-      var found = false;
       var results = [];
       Object.keys(keyPairs).forEach(function(keyName) {
         var keyVal = keyPairs[keyName];
@@ -175,22 +174,21 @@ module.exports = {
           );
         }
         results.push(o[keyName] == keyVal);
-      })
-      results.forEach(function(item) {
-        if (results[0] != item) {
-          throw new Error(
-            "Illegal state: provided search keys were partially matched on the target objects"
-          );
-        }
-        found = item;
       });
+
+      var found = results[0];
+      if (!results.every(val => val === found)) {
+        throw new Error(
+          "Illegal state: search keys were only partially matched when searching collection"
+        );
+      }
       return found;
     });
 
     var matchedObject = {};
     if (filteredObjects.length > 1) {
       throw new Error(
-        "Illegal state: multiple objects matching the search keys"
+        "Illegal state: search keys were matched multiple times when searching collection"
       );
     }
     if (filteredObjects.length == 1) {

--- a/app/src/utils/utils.js
+++ b/app/src/utils/utils.js
@@ -163,26 +163,35 @@ module.exports = {
    */
   findObject: function(keyPairs, objects) {
     var filteredObjects = _.filter(objects, function(o) {
-      var found = true;
-
+      var found = false;
+      var results = [];
       Object.keys(keyPairs).forEach(function(keyName) {
         var keyVal = keyPairs[keyName];
         if (_.isEmpty(keyVal)) {
-          found = false;
+          results.push(false);
           log.error(
             "",
             "An empty search key was provided preventing an object match."
           );
         }
-        found &= o[keyName] == keyVal;
+        results.push(o[keyName] == keyVal);
+      })
+      results.forEach(function(item) {
+        if (results[0] != item) {
+          throw new Error(
+            "Illegal state: provided search keys were partially matched on the target objects"
+          );
+        }
+        found = item;
       });
-
       return found;
     });
 
     var matchedObject = {};
     if (filteredObjects.length > 1) {
-      throw new Error();
+      throw new Error(
+        "Illegal state: multiple objects matching the search keys"
+      );
     }
     if (filteredObjects.length == 1) {
       matchedObject = filteredObjects[0];


### PR DESCRIPTION
Following our Slack conversation, utils.findObject() should throw an error when partially matching results.