### PR TITLE
INFRA-427: Upgrade Jenkins Core to 2.426.3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=2.387.3
+ARG VERSION=2.426.3
 FROM jenkins/jenkins:$VERSION
 MAINTAINER Mekom Solutions <support@mekomsolutions.com>
 

--- a/docker/config/plugins.txt
+++ b/docker/config/plugins.txt
@@ -1,12 +1,12 @@
-git:5.2.0
+git:5.2.1
 ansicolor:1.0.2
 workflow-aggregator:590.v6a_d052e5a_a_b_5
 nodejs:1.5.1
 envinject:2.866.v5c0403e3d4df
 conditional-buildstep:1.4.2
-parameterized-trigger:2.45
+parameterized-trigger:2.46
 build-name-setter:2.2.0
-pipeline-build-step:496.v2449a_9a_221f2
+pipeline-build-step:540.vb_e8849e1a_b_d8
 generic-webhook-trigger:1.84
 matrix-auth:3.1.5
 pipeline-utility-steps:2.13.0


### PR DESCRIPTION
The Upgrade Jenkins Core to 2.426.3 to fix an issue we ran into in Prod after deploying INFRA-427