### PR TITLE
INFRA-466: Create env file when only artifacts change a

### DIFF
--- a/node-scripts/src/pipeline3/impl/dockerComposeFromArtifact.js
+++ b/node-scripts/src/pipeline3/impl/dockerComposeFromArtifact.js
@@ -220,6 +220,7 @@ module.exports = {
       return script;
     },
     getArtifactsScript: function(instanceDef) {
+      // `dockerComposeFromArtifact` deployment type requires to apply deployment scripts changes even upon artifact changes.
       return this.getDeploymentScript(instanceDef);
     }
   },

--- a/node-scripts/src/pipeline3/impl/dockerComposeFromArtifact.js
+++ b/node-scripts/src/pipeline3/impl/dockerComposeFromArtifact.js
@@ -76,7 +76,7 @@ module.exports = {
           mavenProject,
           "maven",
           dockerDirPath,
-          null
+          instanceDef.deployment.value.mavenUrl
         );
       }
       return script;
@@ -220,7 +220,7 @@ module.exports = {
       return script;
     },
     getArtifactsScript: function(instanceDef) {
-      return "";
+      return this.getDeploymentScript(instanceDef);
     }
   },
   startInstance: {


### PR DESCRIPTION
The PR fixes to bugs

- `dockerComposeFromArtifact` type not able to fetch private artifacts
- `dockerComposeFromArtifact` type not creating a necessary env file when only artifacts change.