### PR TITLE
MG-3: Add support for running Docker commands with sudo

### DIFF
--- a/docker/config/plugins.txt
+++ b/docker/config/plugins.txt
@@ -1,4 +1,4 @@
-git:5.2.2
+git:5.7.0
 ansicolor:1.0.2
 workflow-aggregator:600.vb_57cdd26fdd7
 nodejs:1.6.1

--- a/node-scripts/spec/pipeline3/scripts.spec.js
+++ b/node-scripts/spec/pipeline3/scripts.spec.js
@@ -11,6 +11,7 @@ describe("Scripts", function() {
   const cst = require(path.resolve("src/const"));
   const dockerContainer = require(path.resolve("src/pipeline3/impl/docker"));
   const heredoc = cst.HEREDOC;
+  const heredoc_2 = cst.HEREDOC_2;
 
   const scripts = require(path.resolve(
     "src/" + config.getJobNameForPipeline3() + "/scripts"
@@ -49,7 +50,7 @@ describe("Scripts", function() {
     };
 
     expect(scripts.remote(ssh, "echo test")).toEqual(
-      "sudo ssh -T " +
+      "ssh -T " +
         ssh.user +
         "@" +
         ssh.ip +
@@ -59,7 +60,12 @@ describe("Scripts", function() {
         " --login <<" +
         heredoc +
         "\n" +
+        "sudo /bin/bash --login <<" +
+        heredoc_2 +
+        "\n" +
         "echo test\n" +
+        heredoc_2 +
+        "\n" +
         heredoc +
         "\n"
     );

--- a/node-scripts/spec/pipeline3/scripts.spec.js
+++ b/node-scripts/spec/pipeline3/scripts.spec.js
@@ -17,14 +17,12 @@ describe("Scripts", function() {
   ));
 
   it("should generate remote commands.", function() {
-    // setup
     var ssh = {
       user: "user",
       ip: "host",
       port: "22"
     };
 
-    // verif
     expect(scripts.remote(ssh, "echo test")).toEqual(
       "ssh -T " +
         ssh.user +
@@ -43,7 +41,6 @@ describe("Scripts", function() {
   });
 
   it("should generate remote commands with sudo when sudo is true.", function() {
-    // setup
     var ssh = {
       user: "user",
       ip: "host",
@@ -51,7 +48,6 @@ describe("Scripts", function() {
       sudo: true
     };
 
-    // verif
     expect(scripts.remote(ssh, "echo test")).toEqual(
       "sudo ssh -T " +
         ssh.user +
@@ -70,7 +66,6 @@ describe("Scripts", function() {
   });
 
   it("should not generate remote commands with sudo when sudo is false or undefined.", function() {
-    // setup
     var ssh1 = {
       user: "user",
       ip: "host",
@@ -139,7 +134,6 @@ describe("Scripts", function() {
   });
 
   it("should generate rsync commands.", function() {
-    // setup
     var ssh = {
       user: "user",
       ip: "host",

--- a/node-scripts/spec/pipeline3/scripts.spec.js
+++ b/node-scripts/spec/pipeline3/scripts.spec.js
@@ -42,6 +42,80 @@ describe("Scripts", function() {
     );
   });
 
+  it("should generate remote commands with sudo when sudo is true.", function() {
+    // setup
+    var ssh = {
+      user: "user",
+      ip: "host",
+      port: "22",
+      sudo: true
+    };
+
+    // verif
+    expect(scripts.remote(ssh, "echo test")).toEqual(
+      "sudo ssh -T " +
+        ssh.user +
+        "@" +
+        ssh.ip +
+        " -p " +
+        ssh.port +
+        " /bin/bash" +
+        " --login <<" +
+        heredoc +
+        "\n" +
+        "echo test\n" +
+        heredoc +
+        "\n"
+    );
+  });
+
+  it("should not generate remote commands with sudo when sudo is false or undefined.", function() {
+    // setup
+    var ssh1 = {
+      user: "user",
+      ip: "host",
+      port: "22",
+      sudo: false
+    };
+    var ssh2 = {
+      user: "user",
+      ip: "host",
+      port: "22"
+    };
+
+    // verif
+    expect(scripts.remote(ssh1, "echo test")).toEqual(
+      "ssh -T " +
+        ssh1.user +
+        "@" +
+        ssh1.ip +
+        " -p " +
+        ssh1.port +
+        " /bin/bash" +
+        " --login <<" +
+        heredoc +
+        "\n" +
+        "echo test\n" +
+        heredoc +
+        "\n"
+    );
+    expect(scripts.remote(ssh2, "echo test")).toEqual(
+      "ssh -T " +
+        ssh2.user +
+        "@" +
+        ssh2.ip +
+        " -p " +
+        ssh2.port +
+        " /bin/bash" +
+        " --login <<" +
+        heredoc +
+        "\n" +
+        "echo test\n" +
+        heredoc +
+        "\n"
+    );
+  });
+
   it("should add or remove trailing slashes to directory paths.", function() {
     expect(scripts.trailSlash("foo", true)).toEqual("foo/");
     expect(scripts.trailSlash("foo/", true)).toEqual("foo/");

--- a/node-scripts/src/pipeline3/scripts.js
+++ b/node-scripts/src/pipeline3/scripts.js
@@ -181,7 +181,8 @@ module.exports = {
    *    {
    *      user: "cdagent",
    *      ip: "10.99.0.4",
-   *      port: "22"
+   *      port: "22",
+   *      sudo: true
    *    }
    *
    * @param {String} script - The script to become a remote script.
@@ -197,6 +198,9 @@ module.exports = {
       ssh.shell = "/bin/bash";
     }
 
+    if (ssh.sudo === true) {
+      remoteScript += "sudo ";
+    }
     remoteScript +=
       "ssh -T " +
       ssh.user +

--- a/node-scripts/src/pipeline3/scripts.js
+++ b/node-scripts/src/pipeline3/scripts.js
@@ -198,9 +198,6 @@ module.exports = {
       ssh.shell = "/bin/bash";
     }
 
-    if (ssh.sudo === true) {
-      remoteScript += "sudo ";
-    }
     remoteScript +=
       "ssh -T " +
       ssh.user +
@@ -213,7 +210,14 @@ module.exports = {
       " --login <<" +
       heredoc +
       "\n";
+    if (ssh.sudo === true) {
+      remoteScript += "sudo " + ssh.shell + " --login <<" + heredoc_2 + "\n";
+    }
     remoteScript += script;
+    if (ssh.sudo === true) {
+      remoteScript += heredoc_2;
+      remoteScript += "\n";
+    }
     remoteScript += heredoc;
 
     script = remoteScript + "\n";


### PR DESCRIPTION
The server provided by DIGI requires running Docker as sudo. Instead of making is sudoless I have opted ot add support for sudo to OCD3 https://uwdigi.atlassian.net/browse/MG-3


With `sudo: true`
<img width="1493" height="823" alt="image" src="https://github.com/user-attachments/assets/bf48ce62-011e-48af-92dd-21bf7d8bb11d" />

Without `sudo:true`

<img width="1511" height="897" alt="image" src="https://github.com/user-attachments/assets/72bfe123-bf64-4a1a-9c14-a56a8841e1d8" />
